### PR TITLE
json: fix potential overflow

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -780,7 +780,7 @@ json::parsing::parse_results json::parsing::parse(const char *input)
     json::reader stream;
 
     // Iterate
-    while(!EMPTY_STRING(input) && stream.push(*index) != json::reader::REJECTED)
+    while(!EMPTY_STRING(index) && stream.push(*index) != json::reader::REJECTED)
     {
         index++;
     }


### PR DESCRIPTION
The code:

```cpp
    while(!EMPTY_STRING(input) && stream.push(*index) != json::reader::REJECTED)
    {
        index++;
    }
```

Runs into an issue because `EMPTY_STRING(input)` is used to check for null-pointer ending, but `input` is never incremented during the loop. As such, an overflow will happen when `index` has incremented beyond it's buffer and `*index` is run. This triggers an overflow on the `input` buffer as `index` is declared as:

`const char *index = json::parsing::tlws(input);`

Instead of checking for an empty string on `input` we should check it on `index`.