### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
+                      pkg-config curl check
+COPY . $SRC/simpleson
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/fuzzer.cpp $SRC/fuzzer.cpp
+WORKDIR simpleson

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+mkdir fuzz-build
+cd fuzz-build
+cmake -DCMAKE_VERBOSE_MAKEFILE=ON ../
+make V=1 || true
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.cpp -Wl,--whole-archive $SRC/simpleson/fuzz-build/libsimpleson.a -Wl,--allow-multiple-definition -I$SRC/simpleson/  -o $OUT/fuzzer

--- a/.clusterfuzzlite/fuzzer.cpp
+++ b/.clusterfuzzlite/fuzzer.cpp
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "json.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) {
+        return 0;
+    }
+
+    // Copy input data to a null-terminated string
+    char* input = new char[size + 1];
+    memcpy(input, data, size);
+    input[size] = '\0';
+
+    try {
+        json::jobject::parse(input);
+    } catch (...) {
+        // Catch all exceptions thrown by the target code
+    }
+
+    delete[] input;
+
+    return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/simpleson
cd simpleson
git checkout CIFuzz-integration

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD fuzzer -- -max_total_time=10
```

For reference, this was used to find the issue fixed in https://github.com/gregjesl/simpleson/pull/39 and you can trigger the issue by running the above commands as well.