### PR TITLE
Fix errors associated with Borland C++ Builder 5

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -872,7 +872,6 @@ json::jobject json::jobject::parse(const char *input)
         break;
     default:
         throw json::parsing_error(error);
-        break;
     }
     index++;
     SKIP_WHITE_SPACE(index);

--- a/json.h
+++ b/json.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <stdexcept>
 #include <cctype>
+#include <map>
 
 /*! \brief Base namespace for simpleson */
 namespace json
@@ -461,7 +462,7 @@ namespace json
 		bool operator!= (const json::jobject other) const { return ((std::string)(*this)) != (std::string)other; }
 
 		/*! \brief Assignment operator */
-		inline jobject& operator=(const jobject rhs)
+		inline jobject& operator=(const jobject& rhs)
 		{
 			this->array_flag = rhs.array_flag;
 			this->data = rhs.data;
@@ -598,6 +599,18 @@ namespace json
 		void remove(const size_t index)
 		{
 			this->data.erase(this->data.begin() + index);
+		}
+
+		/*! \brief Returns the key/value pairs of a JSONObject as a map<string, string>
+		 */
+		inline std::map<std::string, std::string> to_map() const
+		{
+			std::map<std::string, std::string> map;
+			std::vector<json::kvp> kvps = this->data;
+			for (std::vector<json::kvp>::const_iterator it = kvps.begin(); it != kvps.end(); ++it) {
+				map[it->first] = json::parsing::decode_string(it->second.c_str());
+			}
+			return map;
 		}
 
 		/*! \brief Representation of a value in the object */
@@ -847,6 +860,7 @@ namespace json
 		private:
 			/*! \brief The source object the value is referencing */
 			const jobject &source;
+			mutable std::string value;
 
 		protected:
 			/*! \brief The key for the referenced value */
@@ -855,8 +869,8 @@ namespace json
 			/*! \brief Returns a reference to the value */
 			inline const std::string& ref() const 
 			{
-				for (size_t i = 0; i < this->source.size(); i++) if (this->source.data.at(i).first == key) return this->source.data.at(i).second;
-				throw json::invalid_key(key);
+				value = this->source.get(this->key);
+				return value;
 			}
 
 		public:

--- a/json.h
+++ b/json.h
@@ -103,7 +103,7 @@ namespace json
 		/*! \brief Length field exposed */
 		using std::string::length;
 
-		#if __GNUC__ && __GNUC__ < 11
+		#if __cplusplus < 201103L || (__GNUC__ && __GNUC__ < 11)
 		inline char front() const { return this->at(0); }
 		inline char back() const { return this->at(this->length() - 1); }
 		#else

--- a/json.h
+++ b/json.h
@@ -601,7 +601,7 @@ namespace json
 			this->data.erase(this->data.begin() + index);
 		}
 
-		/*! \brief Returns the key/value pairs of a JSONObject as a map<string, string>
+		/*! \brief Returns key/value pairs as a map<string, string>
 		 */
 		inline std::map<std::string, std::string> to_map() const
 		{

--- a/json.h
+++ b/json.h
@@ -881,7 +881,7 @@ namespace json
 			 */
 			const_proxy(const jobject &source, const std::string key) : source(source), key(key) 
 			{ 
-				if(source.array_flag) throw std::logic_error("Source cannot be an array");
+				if(source.is_array()) throw std::logic_error("Source cannot be an array");
 			}
 
 			/*! \brief Returns another constant value from this array


### PR DESCRIPTION
I am working on a project targeting Windows 98 which contains simpleson for parsing config files. These fixes enabled me to successfully compile using C++ Builder 5, which is not 100% C++98 compliant. I also added a utility method which I found useful for returning kvps as a std::map